### PR TITLE
Support for the OMMX Python SDK v2.0.0

### DIFF
--- a/ommx_fixstars_amplify_adapter/adapter.py
+++ b/ommx_fixstars_amplify_adapter/adapter.py
@@ -1,21 +1,14 @@
 import amplify
 
-from typing import Union
-
 from ommx.v1 import (
     Solution,
     Instance,
     DecisionVariable,
     Constraint,
+    Function,
     State,
 )
-from ommx.v1.function_pb2 import Function
 from ommx.adapter import SolverAdapter
-from ommx.v1.linear_pb2 import Linear
-from ommx.v1.quadratic_pb2 import Quadratic
-from ommx.v1.polynomial_pb2 import Polynomial
-from ommx.v1.constraint_pb2 import Constraint as RawConstraint
-from ommx.v1.decision_variables_pb2 import DecisionVariable as RawDVar
 
 from .exception import OMMXFixstarsAmplifyAdapterError
 
@@ -175,7 +168,7 @@ class OMMXFixstarsAmplifyAdapter(SolverAdapter):
     def _set_decision_variables(self):
         self.variable_map = {}
         gen = amplify.VariableGenerator()
-        for var in self.instance.raw.decision_variables:
+        for var in self.instance.get_decision_variables():
             if var.kind == DecisionVariable.BINARY:
                 amplify_var = gen.scalar(
                     "Binary",
@@ -200,18 +193,18 @@ class OMMXFixstarsAmplifyAdapter(SolverAdapter):
             self.variable_map[var.id] = amplify_var
 
     def _set_objective(self):
-        obj_poly = self._function_to_poly(self.instance.raw.objective)
-        if self.instance.raw.sense == Instance.MINIMIZE:
+        obj_poly = self._function_to_poly(self.instance.objective)
+        if self.instance.sense == Instance.MINIMIZE:
             self.model += obj_poly
-        elif self.instance.raw.sense == Instance.MAXIMIZE:
+        elif self.instance.sense == Instance.MAXIMIZE:
             self.model += -obj_poly
         else:
             raise OMMXFixstarsAmplifyAdapterError(
-                f"Unknown sense: {self.instance.raw.sense}"
+                f"Unknown sense: {self.instance.sense}"
             )
 
     def _set_constraints(self):
-        for constr in self.instance.raw.constraints:
+        for constr in self.instance.get_constraints():
             function_poly = self._function_to_poly(constr.function)
             if constr.equality == Constraint.EQUAL_TO_ZERO:
                 self.model += amplify.equal_to(
@@ -227,61 +220,26 @@ class OMMXFixstarsAmplifyAdapter(SolverAdapter):
                 )
 
     def _function_to_poly(
-        self, func: Union[float, Linear, Quadratic, Polynomial, Function]
+        self,
+        func: Function,
     ) -> amplify.Poly:
-        if isinstance(func, (float, int)):
-            return amplify.Poly(float(func))
-
-        elif isinstance(func, Linear):
-            poly = amplify.Poly(func.constant)
-            for term in func.terms:
-                var = self.variable_map[term.id]
-                poly += term.coefficient * var
-            return poly
-
-        elif isinstance(func, Quadratic):
-            poly = amplify.Poly()
-            for col, row, value in zip(func.columns, func.rows, func.values):
-                var_col = self.variable_map[col]
-                var_row = self.variable_map[row]
-                poly += value * var_col * var_row
-            poly += self._function_to_poly(func.linear)
-            return poly
-
-        elif isinstance(func, Polynomial):
-            poly = amplify.Poly()
-            for monomial in func.terms:
-                term = monomial.coefficient
-                for var_id in monomial.ids:
-                    term *= self.variable_map[var_id]
-                poly += term
-            return poly
-
-        elif isinstance(func, Function):
-            if func.HasField("constant"):
-                return amplify.Poly(func.constant)
-            if func.HasField("linear"):
-                return self._function_to_poly(func.linear)
-            elif func.HasField("quadratic"):
-                return self._function_to_poly(func.quadratic)
-            elif func.HasField("polynomial"):
-                return self._function_to_poly(func.polynomial)
+        poly = amplify.Poly(0)
+        for ids, coefficient in func.terms.items():
+            if len(ids) == 0:
+                poly += coefficient
             else:
-                raise OMMXFixstarsAmplifyAdapterError(
-                    f"Unknown fields in Function: {func}"
-                )
-
-        else:
-            raise OMMXFixstarsAmplifyAdapterError(
-                f"Unknown function type: {type(func)}"
-            )
+                term = coefficient
+                for id in ids:
+                    term *= self.variable_map[id]
+                poly += term
+        return poly
 
 
-def _make_constraint_label(constraint: RawConstraint) -> str:
+def _make_constraint_label(constraint: Constraint) -> str:
     return f"{constraint.name} [id: {constraint.id}]"
 
 
-def _make_variable_label(variable: RawDVar) -> str:
+def _make_variable_label(variable: DecisionVariable) -> str:
     if len(variable.subscripts) == 0:
         return variable.name
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "ommx >= 1.8.5, < 2.0.0",
+    "ommx >= 2.0.0b3, < 3.0.0",
     "amplify >= 1.2.0, < 2.0.0", 
 ]
 

--- a/tests/test_model_to_instance.py
+++ b/tests/test_model_to_instance.py
@@ -37,105 +37,87 @@ def test_model_to_instance():
     model += amplify.clamp(w, (16, 17))
     ommx_instance = model_to_instance(model)
 
-    assert len(ommx_instance.raw.decision_variables) == 4
+    assert len(ommx_instance.get_decision_variables()) == 4
     # Check the decision variable `x`
-    assert ommx_instance.raw.decision_variables[0].id == 0
-    assert ommx_instance.raw.decision_variables[0].kind == DecisionVariable.BINARY
-    assert ommx_instance.raw.decision_variables[0].name == "x"
-    assert ommx_instance.raw.decision_variables[0].bound.lower == 0
-    assert ommx_instance.raw.decision_variables[0].bound.upper == 1
+    assert ommx_instance.get_decision_variable(0).kind == DecisionVariable.BINARY
+    assert ommx_instance.get_decision_variable(0).name == "x"
+    assert ommx_instance.get_decision_variable(0).bound.lower == 0
+    assert ommx_instance.get_decision_variable(0).bound.upper == 1
     # Check the decision variable `y`
-    assert ommx_instance.raw.decision_variables[1].id == 1
-    assert ommx_instance.raw.decision_variables[1].kind == DecisionVariable.INTEGER
-    assert ommx_instance.raw.decision_variables[1].name == "y"
-    assert ommx_instance.raw.decision_variables[1].bound.lower == -20
-    assert ommx_instance.raw.decision_variables[1].bound.upper == 20
+    assert ommx_instance.get_decision_variable(1).kind == DecisionVariable.INTEGER
+    assert ommx_instance.get_decision_variable(1).name == "y"
+    assert ommx_instance.get_decision_variable(1).bound.lower == -20
+    assert ommx_instance.get_decision_variable(1).bound.upper == 20
     # Check the decision variable `z`
-    assert ommx_instance.raw.decision_variables[2].id == 2
-    assert ommx_instance.raw.decision_variables[2].kind == DecisionVariable.CONTINUOUS
-    assert ommx_instance.raw.decision_variables[2].name == "z"
-    assert ommx_instance.raw.decision_variables[2].bound.lower == -30
-    assert ommx_instance.raw.decision_variables[2].bound.upper == 30
+    assert ommx_instance.get_decision_variable(2).kind == DecisionVariable.CONTINUOUS
+    assert ommx_instance.get_decision_variable(2).name == "z"
+    assert ommx_instance.get_decision_variable(2).bound.lower == -30
+    assert ommx_instance.get_decision_variable(2).bound.upper == 30
     # Check the decision variable `w`
-    assert ommx_instance.raw.decision_variables[3].id == 3
-    assert ommx_instance.raw.decision_variables[3].kind == DecisionVariable.CONTINUOUS
-    assert ommx_instance.raw.decision_variables[3].name == "w"
-    assert ommx_instance.raw.decision_variables[3].bound.lower == float("-inf")
-    assert ommx_instance.raw.decision_variables[3].bound.upper == float("inf")
+    assert ommx_instance.get_decision_variable(3).kind == DecisionVariable.CONTINUOUS
+    assert ommx_instance.get_decision_variable(3).name == "w"
+    assert ommx_instance.get_decision_variable(3).bound.lower == float("-inf")
+    assert ommx_instance.get_decision_variable(3).bound.upper == float("inf")
 
     # Check the objective function: 2xyz + 3yz + 4z + 5
-    objective = ommx_instance.raw.objective
-    assert objective.HasField("polynomial")
-    assert len(objective.polynomial.terms) == 4
-    assert objective.polynomial.terms[0].ids == [0, 1, 2]
-    assert objective.polynomial.terms[0].coefficient == 2.0
-    assert objective.polynomial.terms[1].ids == [1, 2]
-    assert objective.polynomial.terms[1].coefficient == 3.0
-    assert objective.polynomial.terms[2].ids == [2]
-    assert objective.polynomial.terms[2].coefficient == 4.0
-    assert objective.polynomial.terms[3].ids == []
-    assert objective.polynomial.terms[3].coefficient == 5.0
+    assert ommx_instance.objective.terms == {
+        (0, 1, 2): 2.0,
+        (1, 2): 3.0,
+        (2,): 4.0,
+        (): 5.0,
+    }
 
     # Check the number of constraints
-    assert len(ommx_instance.raw.constraints) == 5
+    assert len(ommx_instance.get_constraints()) == 5
 
     # Check the first constraint: 6x + 7y + 8z -9 <= 0
-    constraint1 = ommx_instance.raw.constraints[0]
-    assert constraint1.equality == Constraint.LESS_THAN_OR_EQUAL_TO_ZERO
-    assert constraint1.function.HasField("linear")
-    assert len(constraint1.function.linear.terms) == 3
-    assert constraint1.function.linear.terms[0].id == 0
-    assert constraint1.function.linear.terms[0].coefficient == 6.0
-    assert constraint1.function.linear.terms[1].id == 1
-    assert constraint1.function.linear.terms[1].coefficient == 7.0
-    assert constraint1.function.linear.terms[2].id == 2
-    assert constraint1.function.linear.terms[2].coefficient == 8.0
-    assert constraint1.function.linear.constant == -9.0
+    assert (
+        ommx_instance.get_constraint(0).equality
+        == Constraint.LESS_THAN_OR_EQUAL_TO_ZERO
+    )
+    assert ommx_instance.get_constraint(0).function.terms == {
+        (0,): 6.0,
+        (1,): 7.0,
+        (2,): 8.0,
+        (): -9.0,
+    }
 
     # Check the second constraint: 10xy + 11yz + 12xz -13 = 0
-    constraint2 = ommx_instance.raw.constraints[1]
-    assert constraint2.equality == Constraint.EQUAL_TO_ZERO
-    assert constraint2.function.HasField("quadratic")
-    assert len(constraint2.function.quadratic.columns) == 3
-    assert len(constraint2.function.quadratic.rows) == 3
-    assert len(constraint2.function.quadratic.values) == 3
-    assert constraint2.function.quadratic.columns[0] == 0
-    assert constraint2.function.quadratic.rows[0] == 1
-    assert constraint2.function.quadratic.values[0] == 10
-    assert constraint2.function.quadratic.columns[1] == 1
-    assert constraint2.function.quadratic.rows[1] == 2
-    assert constraint2.function.quadratic.values[1] == 11
-    assert constraint2.function.quadratic.columns[2] == 0
-    assert constraint2.function.quadratic.rows[2] == 2
-    assert constraint2.function.quadratic.values[2] == 12
-    assert constraint2.function.quadratic.linear.terms == []
-    assert constraint2.function.quadratic.linear.constant == -13.0
+    assert ommx_instance.get_constraint(1).equality == Constraint.EQUAL_TO_ZERO
+    assert ommx_instance.get_constraint(1).function.terms == {
+        (0, 1): 10.0,
+        (1, 2): 11.0,
+        (0, 2): 12.0,
+        (): -13.0,
+    }
 
-    # Check the third constraint: 14xyz -15 <= 0
-    constraint3 = ommx_instance.raw.constraints[2]
-    assert constraint3.equality == Constraint.LESS_THAN_OR_EQUAL_TO_ZERO
-    assert constraint3.function.HasField("polynomial")
-    assert len(constraint3.function.polynomial.terms) == 2
-    assert constraint3.function.polynomial.terms[0].ids == [0, 1, 2]
-    assert constraint3.function.polynomial.terms[0].coefficient == -14.0
-    assert constraint3.function.polynomial.terms[1].ids == []
-    assert constraint3.function.polynomial.terms[1].coefficient == 15.0
+    # Check the third constraint: 14xyz -15 >= 0
+    assert (
+        ommx_instance.get_constraint(2).equality
+        == Constraint.LESS_THAN_OR_EQUAL_TO_ZERO
+    )
+    assert ommx_instance.get_constraint(2).function.terms == {
+        (0, 1, 2): -14.0,
+        (): 15.0,
+    }
 
     # Check the fourth constraint: 16 <= w <= 17
-    constraint4 = ommx_instance.raw.constraints[3]
-    assert constraint4.equality == Constraint.LESS_THAN_OR_EQUAL_TO_ZERO
-    assert constraint4.function.HasField("linear")
-    assert len(constraint4.function.linear.terms) == 1
-    assert constraint4.function.linear.terms[0].id == 3
-    assert constraint4.function.linear.terms[0].coefficient == -1.0
-    assert constraint4.function.linear.constant == 16.0
-    constraint5 = ommx_instance.raw.constraints[4]
-    assert constraint5.equality == Constraint.LESS_THAN_OR_EQUAL_TO_ZERO
-    assert constraint5.function.HasField("linear")
-    assert len(constraint5.function.linear.terms) == 1
-    assert constraint5.function.linear.terms[0].id == 3
-    assert constraint5.function.linear.terms[0].coefficient == 1.0
-    assert constraint5.function.linear.constant == -17.0
+    assert (
+        ommx_instance.get_constraint(3).equality
+        == Constraint.LESS_THAN_OR_EQUAL_TO_ZERO
+    )
+    assert ommx_instance.get_constraint(3).function.terms == {
+        (3,): -1.0,
+        (): 16.0,
+    }
+    assert (
+        ommx_instance.get_constraint(4).equality
+        == Constraint.LESS_THAN_OR_EQUAL_TO_ZERO
+    )
+    assert ommx_instance.get_constraint(4).function.terms == {
+        (3,): 1.0,
+        (): -17.0,
+    }
 
 
 def test_builder_decision_variable():
@@ -150,19 +132,19 @@ def test_builder_decision_variable():
     decision_variable = builder.decision_variables()
 
     assert len(decision_variable) == 3
-    assert decision_variable[0].raw.id == 0
-    assert decision_variable[0].raw.kind == DecisionVariable.BINARY
-    assert decision_variable[0].raw.bound.lower == 0
-    assert decision_variable[0].raw.bound.upper == 1
-    assert decision_variable[1].raw.id == 1
-    assert decision_variable[1].raw.kind == DecisionVariable.INTEGER
-    assert decision_variable[1].raw.bound.lower == float("-inf")
-    assert decision_variable[1].raw.bound.upper == float("inf")
-    assert decision_variable[1].raw.name == "y"
-    assert decision_variable[2].raw.id == 2
-    assert decision_variable[2].raw.kind == DecisionVariable.CONTINUOUS
-    assert decision_variable[2].raw.bound.lower == -30
-    assert decision_variable[2].raw.bound.upper == 30
+    assert decision_variable[0].id == 0
+    assert decision_variable[0].kind == DecisionVariable.BINARY
+    assert decision_variable[0].bound.lower == 0
+    assert decision_variable[0].bound.upper == 1
+    assert decision_variable[1].id == 1
+    assert decision_variable[1].kind == DecisionVariable.INTEGER
+    assert decision_variable[1].bound.lower == float("-inf")
+    assert decision_variable[1].bound.upper == float("inf")
+    assert decision_variable[1].name == "y"
+    assert decision_variable[2].id == 2
+    assert decision_variable[2].kind == DecisionVariable.CONTINUOUS
+    assert decision_variable[2].bound.lower == -30
+    assert decision_variable[2].bound.upper == 30
 
 
 def test_error_ising_variable():


### PR DESCRIPTION
本PRは以下の変更を含んでいます。

- OMMX Python SDK v2.0.0系への依存関係の更新
- `OMMXInstanceBuilder` の生成する ` ommx.v1.Instance` に含まれる `Constraint` のIDを明示的に指定するように変更

後者の変更は、同じ `amplify.Model` を `ommx.v1.Instance` に変換しているにも関わらず、1回目の変換と2回目の変換でIDが異なってしまうという仕様を解消するために行ったものです。